### PR TITLE
Nueva corrección en el Puerto en el middleware 'cors' (localhost:5173)

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -32,7 +32,7 @@ app.use(morgan('dev'));
 // Aquí, la URL (Front local) debe sustituirse por la URL del Front desplegado...
 app.use(
   cors({
-    origin: 'http://localhost:5174',
+    origin: 'http://localhost:5173',
     credentials: true,
   }),
 );


### PR DESCRIPTION
Cambio de puerto en el localhost. Se sustituye 5174 por 5173.